### PR TITLE
Travis: Update to latest Rubygems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ sudo: false
 language: ruby
 rvm:
   - 2.3.3
-before_install: gem install bundler -v 1.13.6
+before_install:
+  - gem update --system
+  - gem install bundler -v 1.13.6


### PR DESCRIPTION
This PR adds a step to the build process: update Rubygems to latest.

If this is not in there, Rainbow won't be able to install.
