### PR TITLE
CustomFormatter: Fixed a typo again

### DIFF
--- a/lib/ecraft/logging_library/custom_formatter.rb
+++ b/lib/ecraft/logging_library/custom_formatter.rb
@@ -18,7 +18,7 @@ module Ecraft
                    formatted_colored_logger_name, colored_message)
           else
             # No colorization is needed here, since we draw the assumption that if show_time? is false, we are being redirected.
-            format("%-5s %s: %s\n", severity, logger_name, message_to_s(message))
+            format("%-5s %s: %s\n", severity, logger_name, formatted_message)
           end
         end
 
@@ -107,7 +107,7 @@ module Ecraft
         end
 
         def tty?
-          STDOUT.tty?
+          $stdout.tty?
         end
       end
 


### PR DESCRIPTION
Again, we were calling a method that did not exist, something which Ruby stupidly accepts right away without warnings until very late... I am getting more and more annoyed by this all the time. `method_missing` semantics ought truly to be an opt-in, rather than the default. Annoying!
Hotfixed in customer environment and verified working.