### PR TITLE
Bug fix: The logger name should be set properly for Modules also

### DIFF
--- a/lib/logging_library/mixins/loggable.rb
+++ b/lib/logging_library/mixins/loggable.rb
@@ -12,7 +12,7 @@ module LoggingLibrary
 
       def _logger_name
         # Handle both `extend` and `include` use cases.
-        if self.class == Class
+        if self.class == Class || self.class == Module
           _short_class_name(to_s)
         else
           _short_class_name(self.class.name)

--- a/spec/logging_library/loggable_spec.rb
+++ b/spec/logging_library/loggable_spec.rb
@@ -1,5 +1,25 @@
 module LoggingLibrary
   describe Loggable do
+    context 'when a module includes the Loggable module' do
+      before(:all) do
+        ModuleThatIncludesLoggable = Module.new {
+          extend Loggable
+        }
+      end
+      let(:mod) { ModuleThatIncludesLoggable }
+      subject { mod }
+
+      describe '#logger' do
+        it 'reuses the same logger between calls' do
+          expect(subject.logger).to be subject.logger
+        end
+
+        it 'sets the logger name to the expected value' do
+          expect(subject.logger.name).to eq 'ModuleThatIncludesLoggable'
+        end
+      end
+    end
+
     context 'when a class includes the module' do
       before(:all) do
         ClassThatIncludesLoggable = Class.new {


### PR DESCRIPTION
I noticed this when the Loggable module was being mixed in to a _module_, not a _class_.