### PR TITLE
Bump rubocop dependency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,10 @@
+AllCops:
+  TargetRubyVersion: 1.9
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+
 Lint/EndAlignment:
-  AlignWith: variable
+  EnforcedStyleAlignWith: variable
 
 Metrics/BlockLength:
   Exclude:
@@ -16,9 +21,9 @@ Style/Documentation:
   Enabled: false
 Style/Encoding:
   Enabled: false
-Style/FileName:
+Naming/FileName:
   Enabled: false
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
 inherit_from: .rubocop_todo.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.3
+  - 2.3.4
 before_install:
   - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,4 @@ language: ruby
 rvm:
   - 2.3.3
 before_install:
-  - gem update --system
   - gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,3 @@ gemspec
 group :development do
   gem 'yard'
 end
-

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,3 @@ group :development do
   gem 'yard'
 end
 
-gem 'rubocop', '= 0.50.0'

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ gemspec
 group :development do
   gem 'yard'
 end
+
+gem 'rubocop', '= 0.50.0'

--- a/lib/logging_library/custom_formatter.rb
+++ b/lib/logging_library/custom_formatter.rb
@@ -14,7 +14,7 @@ module LoggingLibrary
       def to_formatted_string
         if show_time?
           format("%s %s %s %s\n", formatted_colored_severity, formatted_colored_time,
-                  formatted_colored_logger_name, colored_message)
+                 formatted_colored_logger_name, colored_message)
         else
           format("%-5s %s %s\n", formatted_colored_severity, formatted_colored_logger_name, colored_message)
         end

--- a/lib/logging_library/logger_factory.rb
+++ b/lib/logging_library/logger_factory.rb
@@ -7,10 +7,12 @@ module LoggingLibrary
 
     # Creates a new `Logger` object.
     #
-    # @param name [String] An optional parameter for overriding the name of the logger. If not provided, a default will be
-    #   determined automatically.
+    # @param name [String] Optional name of the logger. If not provided, a
+    #                      default will be determined from backtrace.
+    #
+    # @return [Logger]
     def create(name = nil)
-      logger_name = name || caller[0][/`.*'/][1..-2]
+      logger_name = name || caller(1..1).first[/`(.+)'/, 1]
       Logger.new(logger_name)
     end
   end

--- a/logging_library.gemspec
+++ b/logging_library.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'logging_library/version'
@@ -27,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.5'
   spec.add_development_dependency 'rspec', '~> 3.5'
-  spec.add_development_dependency 'rubocop', '~> 0.49'
+  spec.add_development_dependency 'rubocop', '~> 0.50', '< 0.51'
   spec.add_development_dependency 'yard', '~> 0.9'
 end

--- a/logging_library.gemspec
+++ b/logging_library.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.5'
   spec.add_development_dependency 'rspec', '~> 3.5'
-  spec.add_development_dependency 'rubocop', '~> 0.46'
+  spec.add_development_dependency 'rubocop', '~> 0.49'
   spec.add_development_dependency 'yard', '~> 0.9'
 end

--- a/spec/logging_library/logger_factory_spec.rb
+++ b/spec/logging_library/logger_factory_spec.rb
@@ -1,0 +1,14 @@
+module LoggingLibrary
+  describe LoggerFactory do
+    it 'takes optional explicit name' do
+      logger = LoggerFactory.create('the-name')
+      expect(logger.name).to eq 'the-name'
+    end
+
+    it 'calculates a default name from backtrace' do
+      logger = LoggerFactory.create
+
+      expect(logger.name).to match(/LoggingLibrary/)
+    end
+  end
+end


### PR DESCRIPTION
The previous dependency can mean an insecure Rubocop version gets pulled in: https://github.com/bbatsov/rubocop/issues/4336

(I have _not_ validated if this changes the `ruby_version` dependency of the package. If so, we should bump the major version of logging_library to make this clear to our dependers.)