### PR TITLE
gemspec: Allow Rainbow 3.0 installs

### DIFF
--- a/logging_library.gemspec
+++ b/logging_library.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'mixlib-log', '~> 1.7'
-  spec.add_runtime_dependency 'rainbow', '~> 2.2'
+  spec.add_runtime_dependency 'rainbow', '>= 2.2'
 
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.5'


### PR DESCRIPTION
This PR relaxes the dependency requirement of Rainbow, to also allow 3.0, for other projects using logging_library.

This project, which uses an older RuboCop, is fixed on 2.x.