### PR TITLE
Added LoggingLibrary.output_device

### DIFF
--- a/lib/logging_library.rb
+++ b/lib/logging_library.rb
@@ -8,6 +8,14 @@ module LoggingLibrary
   Loggable = Mixins::Loggable
 
   LOG_LEVELS = Mixlib::Log::LEVELS.keys.freeze
+
+  class << self
+    def output_device
+      @output_device ||= $stderr
+    end
+
+    attr_writer :output_device
+  end
 end
 
 # Avoid buffering output when running under e.g. Foreman.

--- a/lib/logging_library/custom_formatter.rb
+++ b/lib/logging_library/custom_formatter.rb
@@ -116,7 +116,7 @@ module LoggingLibrary
       end
 
       def tty?
-        $stderr.tty?
+        LoggingLibrary.output_device.tty?
       end
     end
 

--- a/lib/logging_library/logger.rb
+++ b/lib/logging_library/logger.rb
@@ -13,7 +13,7 @@ module LoggingLibrary
     def_delegator :logger, :progname, :name
 
     def initialize(name)
-      init($stderr)
+      init(LoggingLibrary::output_device)
 
       logger.level = :info
       logger.progname = name

--- a/spec/logging_library/loggable_spec.rb
+++ b/spec/logging_library/loggable_spec.rb
@@ -53,15 +53,15 @@ module LoggingLibrary
 
         # DEBUG severity is not printed out by default.
         it "does not print a message to STDERR when sending the 'debug' message" do
-          expect { subject.logger.debug('debug blerp') }.to_not output.to_stderr
+          expect { subject.logger.debug('debug blerp') }.to_not output.to_stderr_from_any_process
         end
 
         it "prints a message to STDERR when sending the 'info' message" do
-          expect { subject.logger.info('info blerp') }.to output(/info blerp/).to_stderr
+          expect { subject.logger.info('info blerp') }.to output(/info blerp/).to_stderr_from_any_process
         end
 
         it "prints a message to STDERR when sending the 'warn' message" do
-          expect { subject.logger.warn('warn blerp') }.to output(/warn blerp/).to_stderr
+          expect { subject.logger.warn('warn blerp') }.to output(/warn blerp/).to_stderr_from_any_process
         end
       end
     end


### PR DESCRIPTION
This makes it easier to silence the logger in specs.