### PR TITLE
Add LOGGING_LIBRARY_DISABLE_TIMESTAMPS override

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ class MyClass
 end
 ```
 
+## Environment variables
+
+- `LOGGING_LIBRARY_DISABLE_TIMESTAMPS` - set this to any value to disable
+  timestamping which is otherwise performed on log entries when running in
+  interactive/TTY mode. This setting can be useful in scenarios where you
+  would otherwise get double timestamps on each line.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then,

--- a/lib/logging_library/custom_formatter.rb
+++ b/lib/logging_library/custom_formatter.rb
@@ -9,8 +9,6 @@ module LoggingLibrary
     DATE_PATTERN = '%Y-%m-%d %H:%M:%S.%L'.freeze
 
     LogMessage = Struct.new(:severity, :time, :logger_name, :message) do
-      LINE_PREPEND = ' ' * 8
-
       def to_formatted_string
         if show_time?
           format("%s %s %s %s\n", formatted_colored_severity, formatted_colored_time,
@@ -19,6 +17,10 @@ module LoggingLibrary
           format("%-5s %s %s\n", formatted_colored_severity, formatted_colored_logger_name, colored_message)
         end
       end
+
+      private
+
+      LINE_PREPEND = ' ' * 8
 
       def colored_message
         return formatted_message unless Rainbow.enabled
@@ -55,7 +57,7 @@ module LoggingLibrary
         if Rainbow.enabled
           Rainbow(formatted_time).color(time_color_for_severity)
         else
-          formatted_severity
+          formatted_time
         end
       end
 
@@ -117,7 +119,11 @@ module LoggingLibrary
         # When STDERR is redirected, we are likely running as a service with a
         # syslog daemon already appending a timestamp to the line (and two
         # timestamps is redundant).
-        tty?
+        tty? && !disable_timestamps?
+      end
+
+      def disable_timestamps?
+        ENV['LOGGING_LIBRARY_DISABLE_TIMESTAMPS']
       end
 
       def tty?

--- a/spec/logging_library/custom_formatter_spec.rb
+++ b/spec/logging_library/custom_formatter_spec.rb
@@ -1,13 +1,13 @@
 module LoggingLibrary
   describe CustomFormatter::LogMessage do
-    describe '#formatted_message' do
+    describe '#to_formatted_string' do
       context 'when message is a Hash' do
         before {
           subject.message = { foo: 'bar' }
         }
 
         it 'returns the expected result' do
-          result = subject.formatted_message
+          result = subject.send(:formatted_message)
           expect(result).to eq '{:foo=>"bar"}'
         end
       end

--- a/spec/logging_library/loggable_spec.rb
+++ b/spec/logging_library/loggable_spec.rb
@@ -63,6 +63,30 @@ module LoggingLibrary
         it "prints a message to STDERR when sending the 'warn' message" do
           expect { subject.logger.warn('warn blerp') }.to output(/warn blerp/).to_stderr_from_any_process
         end
+
+        context 'when LOGGING_LIBRARY_DISABLE_TIMESTAMPS is set' do
+          before {
+            allow(ENV).to receive('[]').and_call_original
+            allow(ENV).to receive('[]').with('LOGGING_LIBRARY_DISABLE_TIMESTAMPS') { '1' }
+            allow_any_instance_of(LoggingLibrary::CustomFormatter::LogMessage).to receive(:tty?) { true }
+          }
+
+          it 'does not include the timestamp in the logged output' do
+            expect { subject.logger.warn('message without timestamp') }.to_not output(/\d{2}:\d{2}:\d{2}/).to_stderr_from_any_process
+          end
+        end
+
+        context 'when LOGGING_LIBRARY_DISABLE_TIMESTAMPS is not set' do
+          before {
+            allow(ENV).to receive('[]').and_call_original
+            allow(ENV).to receive('[]').with('LOGGING_LIBRARY_DISABLE_TIMESTAMPS') { nil }
+            allow_any_instance_of(LoggingLibrary::CustomFormatter::LogMessage).to receive(:tty?) { true }
+          }
+
+          it 'includes the timestamp in the logged output' do
+            expect { subject.logger.warn('message with timestamp') }.to output(/\d{2}:\d{2}:\d{2}/).to_stderr_from_any_process
+          end
+        end
       end
     end
 

--- a/spec/logging_library/loggable_spec.rb
+++ b/spec/logging_library/loggable_spec.rb
@@ -64,6 +64,8 @@ module LoggingLibrary
           expect { subject.logger.warn('warn blerp') }.to output(/warn blerp/).to_stderr_from_any_process
         end
 
+        let(:timestamp_pattern) { /\d{2}:\d{2}:\d{2}/ }
+
         context 'when LOGGING_LIBRARY_DISABLE_TIMESTAMPS is set' do
           before {
             allow(ENV).to receive('[]').and_call_original
@@ -72,7 +74,7 @@ module LoggingLibrary
           }
 
           it 'does not include the timestamp in the logged output' do
-            expect { subject.logger.warn('message without timestamp') }.to_not output(/\d{2}:\d{2}:\d{2}/).to_stderr_from_any_process
+            expect { subject.logger.warn('message without timestamp') }.to_not output(timestamp_pattern).to_stderr_from_any_process
           end
         end
 
@@ -84,7 +86,7 @@ module LoggingLibrary
           }
 
           it 'includes the timestamp in the logged output' do
-            expect { subject.logger.warn('message with timestamp') }.to output(/\d{2}:\d{2}:\d{2}/).to_stderr_from_any_process
+            expect { subject.logger.warn('message with timestamp') }.to output(timestamp_pattern).to_stderr_from_any_process
           end
         end
       end


### PR DESCRIPTION
This is a bit sad; it would be nicer to do this _automatically_ but I can't find a way to do it for now. (to _detect_ that `docker exec -t foo` has been used, but no `docker exec -i` or -`it`)

The root problem is this: I want to eliminate double timestamping on these lines:

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/630613/37894634-7a8a9374-30e7-11e8-96de-4048b5f6b9bb.png">

The left-most timestamps (added by Docker and/or Rancher) is enough; we don't need the logging output in the server/etc to _also_ add its own timestamp in these cases.