### PR TITLE
gemspec: Use Bundler 2.x

### DIFF
--- a/logging_library.gemspec
+++ b/logging_library.gemspec
@@ -27,9 +27,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'mixlib-log', '~> 1.7'
   spec.add_runtime_dependency 'rainbow', '>= 2.2'
 
-  spec.add_development_dependency 'bundler', '~> 1.13'
+  spec.add_development_dependency 'bundler', '>= 2.0'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.5'
-  spec.add_development_dependency 'rubocop', '~> 0.54'
+  spec.add_development_dependency 'rubocop', '~> 0.54.0'
   spec.add_development_dependency 'yard', '~> 0.9'
 end


### PR DESCRIPTION
As can be seen in the job output for #19, the project [does not currently build](https://travis-ci.org/github/ecraft/logging_library/builds/664358427?utm_source=github_status&utm_medium=notification) on Travis CI. This PR fixes that.